### PR TITLE
Add more checks about LAS formats with PointAttribute::RGB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcc:14.2 AS build
 
-RUN apt-get update && apt-get -y install cmake sqlite3
+RUN apt-get update && apt-get -y install cmake sqlite3 libboost-system-dev libboost-iostreams-dev libboost-program-options-dev
 
 RUN mkdir /data
 WORKDIR /data
@@ -16,7 +16,7 @@ RUN mkdir Schwarzwald
 WORKDIR /data/Schwarzwald
 ADD . /data/Schwarzwald
 RUN rm -rf build && mkdir build
-RUN cd build && cmake -DCMAKE_BUILD_TYPE=Release -DLASZIP_INCLUDE_DIRS=/data/LAStools/LASzip/dll -DLASZIP_LIBRARY=/data/LAStools/LASzip/build/src/liblaszip.so .. 
+RUN cd build && cmake -DCMAKE_BUILD_TYPE=Release -DLASZIP_INCLUDE_DIRS=/data/LAStools/LASzip/dll -DLASZIP_LIBRARY=/data/LAStools/LASzip/build/src/liblaszip.so ..
 RUN cd build && make -j`nproc`
 
 # copy libproj.so dependency to a temporary directory

--- a/schwarzwald/core/CMakeLists.txt
+++ b/schwarzwald/core/CMakeLists.txt
@@ -70,7 +70,7 @@ set(SOURCE_FILES
     process/Tiler.h
     process/TilerProcess.cpp
     process/TilerProcess.h
-    
+
     util/Config.h
     util/Config.cpp
     util/Definitions.h
@@ -116,7 +116,7 @@ find_package(Microsoft.GSL CONFIG REQUIRED)
 hunter_add_package(glm)
 find_package(glm REQUIRED)
 
-hunter_add_package(Boost COMPONENTS system program_options iostreams)
+#hunter_add_package(Boost COMPONENTS system program_options iostreams)
 find_package(Boost CONFIG REQUIRED system program_options iostreams)
 
 hunter_add_package(RapidJSON)
@@ -129,31 +129,31 @@ add_library(SchwarzwaldCore STATIC ${SOURCE_FILES} ${lib_tl_expected_files})
 target_include_directories(SchwarzwaldCore PUBLIC . include ${LASZIP_INCLUDE_DIRS} ${TL_EXPECTED_INCLUDE_DIRS})
 
 if(UNIX)
-	target_link_libraries(SchwarzwaldCore 
+	target_link_libraries(SchwarzwaldCore
         PUBLIC 	util
-                ${LASZIP_LIBRARY} 
-				proj 
-				Microsoft.GSL::GSL 
+                ${LASZIP_LIBRARY}
+				proj
+				Microsoft.GSL::GSL
 				Boost::program_options
 				Boost::system
                 Boost::iostreams
                 RapidJSON::rapidjson
-		PRIVATE 
-				glm 
+		PRIVATE
+				glm
                 Threads::Threads
 				-lstdc++fs)
 else()
-	target_link_libraries(SchwarzwaldCore 
-        PUBLIC 
+	target_link_libraries(SchwarzwaldCore
+        PUBLIC
                 util
-				${LASZIP_LIBRARY} 
-				proj 
-				Microsoft.GSL::GSL 
+				${LASZIP_LIBRARY}
+				proj
+				Microsoft.GSL::GSL
 				Boost::program_options
-				Boost::system 
+				Boost::system
                 Boost::iostreams
                 RapidJSON::rapidjson
-		PRIVATE 
+		PRIVATE
 				glm
                 Threads::Threads)
 endif()

--- a/schwarzwald/core/io/LASFile.cpp
+++ b/schwarzwald/core/io/LASFile.cpp
@@ -418,7 +418,12 @@ las_file_has_attribute(laszip_header const& header, PointAttribute const& attrib
     case PointAttribute::Position:
       return true; // LAS always has positions
     case PointAttribute::RGB:
-      return header.point_data_format == 2 || header.point_data_format == 3;
+    return  header.point_data_format == 2 || // - Format 2: Core-0 + RGB
+            header.point_data_format == 3 || // - Format 3: Core-0 + GPS + RGB
+            header.point_data_format == 5 || // - Format 5: Format 3 + wave packets
+            header.point_data_format == 7 || // - Format 7: Core-6 + RGB
+            header.point_data_format == 8 || // - Format 8: Format 7 + NIR
+            header.point_data_format == 10;  // - Format 10: Format 9 + RGB + NIR
     case PointAttribute::Intensity:
       return true;
     case PointAttribute::Normal:

--- a/schwarzwald/util/CMakeLists.txt
+++ b/schwarzwald/util/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT cista_POPULATED)
 	add_subdirectory(${cista_SOURCE_DIR} ${cista_BINARY_DIR})
 endif()
 
-set(files 
+set(files
 	algorithms/Algorithm.h
 	algorithms/Enums.h
 	algorithms/Hash.h
@@ -36,7 +36,7 @@ set(files
 	concepts/MemoryIntrospection.h
 
 	containers/DestructuringIterator.h
-	
+
 	debug/Journal.h
 	debug/Journal.cpp
 	debug/ProgressReporter.h
@@ -46,7 +46,7 @@ set(files
 
 	io/io_util.h
 	io/io_util.cpp
-	
+
 	logging/Journal.h
 	logging/Journal.cpp
 
@@ -83,7 +83,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_SOURCE_DIR}/build/Release)
 hunter_add_package(Microsoft.GSL)
 find_package(Microsoft.GSL CONFIG REQUIRED)
 
-hunter_add_package(Boost COMPONENTS system program_options iostreams)
+#hunter_add_package(Boost COMPONENTS system program_options iostreams)
 find_package(Boost CONFIG REQUIRED system program_options iostreams)
 
 add_library(util STATIC ${files} ${lib_tl_expected_files})
@@ -91,21 +91,21 @@ add_library(util STATIC ${files} ${lib_tl_expected_files})
 target_include_directories(util PUBLIC . ${TL_EXPECTED_INCLUDE_DIRS} ${cpp-taskflow_SOURCE_DIR} ${cista_include_files})
 
 if(UNIX)
-	target_link_libraries(util 
-		PUBLIC 	
-				Microsoft.GSL::GSL 
+	target_link_libraries(util
+		PUBLIC
+				Microsoft.GSL::GSL
 				Boost::program_options
 				Boost::system
 				Boost::iostreams
 				cista
-		PRIVATE 
+		PRIVATE
 				-lstdc++fs)
 else()
-	target_link_libraries(PointcloudTiler 
-		PUBLIC 
-				Microsoft.GSL::GSL 
+	target_link_libraries(PointcloudTiler
+		PUBLIC
+				Microsoft.GSL::GSL
 				Boost::program_options
-				Boost::system 
+				Boost::system
 				Boost::iostreams
 				cista)
 endif()


### PR DESCRIPTION
According to the LAS file format specification, multiple point data formats support RGB values.

This PR simply enables the `PointAttribute::RGB` for point data formats 2, 3, 5, 7, 8 and 10, instead of only 2 and 3.